### PR TITLE
enable status/stats page for `nginx` and `haproxy`

### DIFF
--- a/docker-compose.core.yml
+++ b/docker-compose.core.yml
@@ -12,6 +12,7 @@ services:
         ports:
             - 15672:15672
             - 5672:5672
+            - 1936:1936
         networks:
             - techcell_backend
         restart: unless-stopped

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -29,8 +29,9 @@ services:
             - letsencrypt_certs:/etc/letsencrypt
             - certbot_acme_challenge:/var/www/certbot
         ports:
-            - '80:80'
-            - '443:443'
+            - 80:80
+            - 443:443
+            - 6644:6644
         healthcheck:
             test: ['CMD', 'nc', '-z', 'nginx', '80']
             interval: 30s

--- a/ssl/nginx-conf/nginx.conf
+++ b/ssl/nginx-conf/nginx.conf
@@ -42,8 +42,7 @@ http {
         location / {
             stub_status on;
             access_log off;
-            allow 127.0.0.1;
-            deny all;
+            allow all;
         }
     }
 

--- a/ssl/nginx-conf/nginx.conf
+++ b/ssl/nginx-conf/nginx.conf
@@ -34,5 +34,18 @@ http {
         '' close;
     }
 
+    server {
+        listen 6644;
+        listen [::]:6644;
+        access_log off;
+        
+        location / {
+            stub_status on;
+            access_log off;
+            allow 127.0.0.1;
+            deny all;
+        }
+    }
+
     include /etc/nginx/conf.d/*.conf;
 }


### PR DESCRIPTION
just only can access status/stats page on local, or forward port from host to local