### PR TITLE
feat(products): add delete product request, add status enum `deleted`

### DIFF
--- a/apps/api/src/controllers/products.controller.ts
+++ b/apps/api/src/controllers/products.controller.ts
@@ -1,4 +1,15 @@
-import { Controller, Inject, Get, Post, Body, Query, Param, Put, UseGuards } from '@nestjs/common';
+import {
+    Controller,
+    Inject,
+    Get,
+    Post,
+    Body,
+    Query,
+    Param,
+    Put,
+    UseGuards,
+    Delete,
+} from '@nestjs/common';
 import { ClientRMQ } from '@nestjs/microservices';
 import { MANAGEMENTS_SERVICE, SEARCH_SERVICE } from '~/constants';
 import { ModGuard, SuperAdminGuard, catchException } from '@app/common';
@@ -19,7 +30,10 @@ import { ProductsMntMessagePattern } from '~/apps/managements/products-mnt';
 import { ProductsSearchMessagePattern } from '~/apps/search/products-search';
 import { GetProductByIdQueryDTO, GetProductsDTO } from '~/apps/search/products-search/dtos';
 import { CreateProductRequestDTO } from '~/apps/managements/products-mnt/dtos';
-import { ProductIdParamsDTO } from '~/apps/managements/products-mnt/dtos/params.dto';
+import {
+    ProductIdParamsDTO,
+    ProductSkuParamsDTO,
+} from '~/apps/managements/products-mnt/dtos/params.dto';
 import { UpdateProductRequestDTO } from '~/apps/managements/products-mnt/dtos/update-product-request.dto';
 import { UpdateProductGeneralImagesDTO } from '~/apps/managements/products-mnt/dtos/update-product-general-images-request.dto';
 
@@ -115,6 +129,37 @@ export class ProductsController {
     async gen(@Query() { num }: { num: number }) {
         return this.managementsService
             .send(ProductsMntMessagePattern.generateProducts, { num })
+            .pipe(catchException());
+    }
+
+    @ApiOperation({
+        summary: 'Delete product by id',
+    })
+    @ApiOkResponse({
+        description: 'Delete product successfully!',
+    })
+    @Delete('/:productId')
+    @UseGuards(ModGuard)
+    async deleteProduct(@Param() { productId }: ProductIdParamsDTO) {
+        return this.managementsService
+            .send(ProductsMntMessagePattern.deleteProduct, { productId })
+            .pipe(catchException());
+    }
+
+    @ApiOperation({
+        summary: 'Delete product variation',
+    })
+    @ApiOkResponse({
+        description: 'Delete product variation successfully!',
+    })
+    @Delete('/:productId/:sku')
+    @UseGuards(ModGuard)
+    async deleteProductVariation(
+        @Param() { productId }: ProductIdParamsDTO,
+        @Param() { sku }: ProductSkuParamsDTO,
+    ) {
+        return this.managementsService
+            .send(ProductsMntMessagePattern.deleteProductVariation, { productId, sku })
             .pipe(catchException());
     }
 }

--- a/apps/managements/src/products-mnt/dtos/params.dto.ts
+++ b/apps/managements/src/products-mnt/dtos/params.dto.ts
@@ -1,5 +1,5 @@
 import { ApiProperty } from '@nestjs/swagger';
-import { IsNotEmpty, IsMongoId } from 'class-validator';
+import { IsNotEmpty, IsMongoId, IsString } from 'class-validator';
 import { Types } from 'mongoose';
 
 export class ProductIdParamsDTO {
@@ -12,4 +12,15 @@ export class ProductIdParamsDTO {
     @IsNotEmpty()
     @IsMongoId({ message: 'Invalid product id' })
     productId: string | Types.ObjectId;
+}
+
+export class ProductSkuParamsDTO {
+    @ApiProperty({
+        type: String,
+        required: true,
+        description: 'A valid product sku',
+    })
+    @IsNotEmpty()
+    @IsString()
+    sku: string;
 }

--- a/apps/managements/src/products-mnt/products-mnt.controller.ts
+++ b/apps/managements/src/products-mnt/products-mnt.controller.ts
@@ -3,7 +3,7 @@ import { MessagePattern, RmqContext, Payload, Ctx } from '@nestjs/microservices'
 import { RabbitMQService } from '@app/common';
 import { ProductsMntService } from './products-mnt.service';
 import { ProductsMntMessagePattern } from './products-mnt.pattern';
-import { ProductIdParamsDTO } from './dtos/params.dto';
+import { ProductIdParamsDTO, ProductSkuParamsDTO } from './dtos/params.dto';
 import { UpdateProductRequestDTO } from './dtos/update-product-request.dto';
 import { CreateProductRequestDTO } from './dtos';
 
@@ -38,5 +38,20 @@ export class ProductsMntController {
     ) {
         this.rabbitMqService.acknowledgeMessage(context);
         return await this.productsMntService.updateProductPutMethod({ ...payload });
+    }
+
+    @MessagePattern(ProductsMntMessagePattern.deleteProduct)
+    async deleteProduct(@Ctx() context: RmqContext, @Payload() { productId }: ProductIdParamsDTO) {
+        this.rabbitMqService.acknowledgeMessage(context);
+        return await this.productsMntService.deleteProduct({ productId });
+    }
+
+    @MessagePattern(ProductsMntMessagePattern.deleteProductVariation)
+    async deleteProductVariation(
+        @Ctx() context: RmqContext,
+        @Payload() { productId, sku }: ProductIdParamsDTO & ProductSkuParamsDTO,
+    ) {
+        this.rabbitMqService.acknowledgeMessage(context);
+        return await this.productsMntService.deleteProductVariation({ productId, sku });
     }
 }

--- a/apps/managements/src/products-mnt/products-mnt.pattern.ts
+++ b/apps/managements/src/products-mnt/products-mnt.pattern.ts
@@ -4,6 +4,8 @@ export const ProductsMntMessagePattern = {
     updateProductGeneralImages: { cmd: 'products_mnt_update_product_general_images' },
     getAllProducts: { cmd: 'products_mnt_get_all_product' },
     generateProducts: { cmd: 'products_mnt_gen_product_gen' },
+    deleteProduct: { cmd: 'products_mnt_delete_product' },
+    deleteProductVariation: { cmd: 'products_mnt_delete_product_variation' },
 };
 
 export const ProductsMntEventPattern = {};

--- a/apps/search/src/dtos/index.ts
+++ b/apps/search/src/dtos/index.ts
@@ -1,0 +1,1 @@
+export * from './select-type.dto';

--- a/apps/search/src/dtos/select-type.dto.ts
+++ b/apps/search/src/dtos/select-type.dto.ts
@@ -1,0 +1,17 @@
+import { ApiProperty } from '@nestjs/swagger';
+import { SelectType } from '../enums';
+import { IsEnum, IsOptional, IsString } from 'class-validator';
+
+export class SelectTypeDTO {
+    @ApiProperty({
+        type: String,
+        enum: SelectType,
+        description: 'Type of select',
+        default: SelectType.onlyActive,
+        required: false,
+    })
+    @IsOptional()
+    @IsString()
+    @IsEnum(SelectType)
+    selectType?: string;
+}

--- a/apps/search/src/enums/index.ts
+++ b/apps/search/src/enums/index.ts
@@ -1,0 +1,1 @@
+export * from './select-type.enum';

--- a/apps/search/src/enums/select-type.enum.ts
+++ b/apps/search/src/enums/select-type.enum.ts
@@ -1,0 +1,5 @@
+export enum SelectType {
+    onlyActive = 'only_active',
+    onlyDeleted = 'only_deleted',
+    both = 'both_deleted_and_active',
+}

--- a/apps/search/src/products-search/dtos/get-products.dto.ts
+++ b/apps/search/src/products-search/dtos/get-products.dto.ts
@@ -1,9 +1,19 @@
-import { IsBoolean, IsNumber, IsOptional, IsString, Max, Min } from 'class-validator';
+import { IsBoolean, IsEnum, IsNumber, IsOptional, IsString, Max, Min } from 'class-validator';
 import { ApiProperty } from '@nestjs/swagger';
 import { MAX_PRODUCTS_PER_PAGE } from '~/constants/product.constant';
 import { Transform, Type } from 'class-transformer';
+import { SelectType } from '~/apps/search/enums';
+import { isTrueSet } from '@app/common';
 
 export class GetProductsDTO {
+    constructor(data: GetProductsDTO) {
+        this.page = data?.page ?? 1;
+        this.pageSize = data?.pageSize ?? 10;
+        this.detail = isTrueSet(data?.detail ?? false);
+        this.select_type = data?.select_type ?? SelectType.onlyActive;
+        this.keyword = data?.keyword ?? undefined;
+    }
+
     @ApiProperty({
         type: Number,
         description: 'Page of products to be returned',
@@ -37,6 +47,18 @@ export class GetProductsDTO {
     @IsOptional()
     @Transform(({ value }) => value === 'true')
     detail?: boolean;
+
+    @ApiProperty({
+        type: String,
+        enum: SelectType,
+        description: 'Type of select',
+        default: SelectType.onlyActive,
+        required: false,
+    })
+    @IsOptional()
+    @IsString()
+    @IsEnum(SelectType)
+    select_type?: string;
 
     @ApiProperty({
         type: String,

--- a/libs/resource/src/products/enums/ProductStatus.enum.ts
+++ b/libs/resource/src/products/enums/ProductStatus.enum.ts
@@ -1,4 +1,5 @@
 export enum ProductStatus {
+    Deleted = -1,
     ComingSoon = 1,
     NewArrival = 2,
     Pre_order = 3,

--- a/libs/resource/src/products/products.service.ts
+++ b/libs/resource/src/products/products.service.ts
@@ -4,44 +4,124 @@ import { ProductsRepository } from './products.repository';
 import { IBaseQuery } from '../interfaces';
 import { Product } from './schemas';
 import { FilterQuery, Types, UpdateQuery } from 'mongoose';
+import { ProductStatus } from './enums';
+import { SelectType } from '~/apps/search/enums';
+import { SelectTypeDTO } from '~/apps/search/dtos';
 
 @Injectable()
 export class ProductsService {
     constructor(private readonly productsRepository: ProductsRepository) {}
 
     async createProduct({ ...createProductDto }: CreateProductDTO) {
-        const product = await this.productsRepository.create({ ...createProductDto });
-        return product;
+        return await this.productsRepository.create({ ...createProductDto });
     }
 
-    async getProduct({ filterQueries, queryOptions, projectionArgs }: IBaseQuery<Product>) {
-        const product = await this.productsRepository.findOne(
-            filterQueries,
-            queryOptions,
-            projectionArgs,
-        );
-        return product;
+    async getProduct({
+        filterQueries,
+        queryOptions,
+        projectionArgs,
+        selectType,
+    }: IBaseQuery<Product> & SelectTypeDTO) {
+        // Resolve the select type
+        switch (selectType) {
+            case SelectType.onlyDeleted:
+                filterQueries.status = {
+                    $eq: ProductStatus.Deleted,
+                };
+                break;
+
+            case SelectType.both:
+                filterQueries.status = {};
+                filterQueries.variations = {};
+                delete filterQueries.status;
+                delete filterQueries.variations;
+                break;
+
+            case SelectType.onlyActive:
+            default:
+                filterQueries.status = { $gt: ProductStatus.Deleted };
+                filterQueries.variations = {
+                    $elemMatch: {
+                        $or: [
+                            { status: { $gt: ProductStatus.Deleted } },
+                            { status: { $exists: false } },
+                        ],
+                    },
+                };
+                break;
+        }
+
+        return await this.productsRepository.findOne(filterQueries, queryOptions, projectionArgs);
     }
 
-    async getProducts({ filterQueries, queryOptions, projectionArgs }: IBaseQuery<Product>) {
-        const products = await this.productsRepository.find({
+    async getProducts({
+        filterQueries,
+        queryOptions,
+        projectionArgs,
+        selectType,
+    }: IBaseQuery<Product> & SelectTypeDTO) {
+        switch (selectType) {
+            case SelectType.onlyDeleted:
+                Object.assign(filterQueries, {
+                    $or: [
+                        { status: ProductStatus.Deleted },
+                        {
+                            status: { $ne: ProductStatus.Deleted },
+                            variations: {
+                                $not: {
+                                    $elemMatch: { status: { $ne: ProductStatus.Deleted } },
+                                },
+                            },
+                        },
+                    ],
+                });
+                break;
+
+            case SelectType.both:
+                filterQueries.status = {};
+                filterQueries.variations = {};
+                delete filterQueries.status;
+                delete filterQueries.variations;
+                break;
+
+            case SelectType.onlyActive:
+                filterQueries.status = { $gt: ProductStatus.Deleted };
+                filterQueries.variations = {
+                    $elemMatch: {
+                        $or: [
+                            { status: { $gt: ProductStatus.Deleted } },
+                            { status: { $exists: false } },
+                        ],
+                    },
+                };
+                break;
+            default:
+                break;
+        }
+
+        return await this.productsRepository.find({
             filterQuery: filterQueries,
             queryOptions,
             projection: projectionArgs,
         });
-        return products;
     }
 
     async countProducts(filterQueries: FilterQuery<Product> = {}) {
-        return this.productsRepository.count(filterQueries);
+        return await this.productsRepository.count(filterQueries);
     }
 
     async updateProductById(
         productId: Types.ObjectId,
         updateQueries: UpdateQuery<Partial<Product>>,
     ) {
-        const product = await this.productsRepository.findOneAndUpdate(productId, updateQueries);
-        return product;
+        return await this.productsRepository.findOneAndUpdate(
+            productId,
+            Object.assign(updateQueries, {
+                $set: {
+                    updatedAt: new Date(),
+                },
+            }),
+        );
     }
 
     async isImageInUse(publicId: string) {
@@ -70,5 +150,18 @@ export class ProductsService {
         } catch (error) {
             return false;
         }
+    }
+
+    async deleteProductById(productId: Types.ObjectId) {
+        const product = await this.productsRepository.findOneAndUpdate(
+            { _id: productId },
+            {
+                $set: {
+                    status: ProductStatus.Deleted,
+                    updatedAt: new Date(),
+                },
+            },
+        );
+        return product;
     }
 }


### PR DESCRIPTION
- update product status, for management need to pass a query `select_type=both_deleted_and_active` to get both. By default just get the active product