### PR TITLE
update(notifications): list return with metadata

### DIFF
--- a/apps/api/src/controllers/notifications.controller.ts
+++ b/apps/api/src/controllers/notifications.controller.ts
@@ -15,7 +15,7 @@ import {
     ApiTooManyRequestsResponse,
     ApiUnauthorizedResponse,
 } from '@nestjs/swagger';
-import { NotificationsDTO } from '@app/resource/notifications/dtos';
+import { ListNotificationsResponseDTO, NotificationsDTO } from '@app/resource/notifications/dtos';
 
 @ApiBadRequestResponse({
     description: 'Invalid request, please check your request data!',
@@ -41,7 +41,7 @@ export class NotificationsController {
         @Inject(COMMUNICATIONS_SERVICE) private readonly communicationsService: ClientRMQ,
     ) {}
 
-    @ApiOkResponse({ description: 'Get user notifications', type: [NotificationsDTO] })
+    @ApiOkResponse({ description: 'Get user notifications', type: ListNotificationsResponseDTO })
     @Get('/')
     async getUserNotifications(
         @Query() { ...query }: GetUserNotificationsDTO,

--- a/apps/communications/src/notifications/services/notifications.service.ts
+++ b/apps/communications/src/notifications/services/notifications.service.ts
@@ -3,6 +3,7 @@ import { Notification, NotificationService } from '@app/resource/notifications';
 import { Injectable } from '@nestjs/common';
 import { QueryOptions, Types } from 'mongoose';
 import { GetUserNotificationsDTO, OrderBy, ReadType } from '../dtos/get-user-notifications.dto';
+import { ListDataResponseDTO } from '@app/common/dtos';
 
 @Injectable()
 export class NotificationsService {
@@ -28,6 +29,18 @@ export class NotificationsService {
             options.sort = { createdAt: -1 };
         }
 
-        return await this.notificationService.getUserNotifications(query, options);
+        const [notifies, totalRecord] = await Promise.all([
+            this.notificationService.getUserNotifications(query, options),
+            this.notificationService.countUserNotifications(query),
+        ]);
+
+        const totalPage = Math.ceil(totalRecord / pageSize);
+        return new ListDataResponseDTO<Notification>({
+            page,
+            pageSize,
+            totalPage,
+            totalRecord,
+            data: notifies,
+        });
     }
 }

--- a/libs/resource/src/notifications/dtos/index.ts
+++ b/libs/resource/src/notifications/dtos/index.ts
@@ -1,2 +1,3 @@
 export * from './create-notify.dto';
 export * from './notifications.dto';
+export * from './list-notifications-response.dto';

--- a/libs/resource/src/notifications/dtos/list-notifications-response.dto.ts
+++ b/libs/resource/src/notifications/dtos/list-notifications-response.dto.ts
@@ -1,0 +1,12 @@
+import { ApiProperty, IntersectionType } from '@nestjs/swagger';
+import { ListDataResponseDTO } from '@app/common/dtos/list-data-response.dto';
+import { NotificationsDTO } from './notifications.dto';
+
+export class ListNotificationsResponseDTO extends IntersectionType(ListDataResponseDTO) {
+    @ApiProperty({
+        type: [NotificationsDTO],
+        description: 'List of users',
+        example: NotificationsDTO,
+    })
+    data: NotificationsDTO[];
+}

--- a/libs/resource/src/notifications/notification.service.ts
+++ b/libs/resource/src/notifications/notification.service.ts
@@ -12,6 +12,10 @@ export class NotificationService {
         return this.notificationRepository.create(notification, {}, session);
     }
 
+    async countUserNotifications(query: FilterQuery<Notification>) {
+        return this.notificationRepository.count(query);
+    }
+
     async getUserNotifications(
         query: FilterQuery<Notification>,
         options?: QueryOptions<Notification>,


### PR DESCRIPTION
This pull request updates the return type of the `getUserNotifications` endpoint to include metadata such as total number of records, total number of pages, and current page number. It also adds a new DTO `ListNotificationsResponseDTO` to handle the updated return type.

No issue number reference needed.