### PR TITLE
Fix validation issues and add payment return URL

### DIFF
--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -107,6 +107,7 @@
         "order",
         "seeder",
         "search",
-        "resources"
+        "resources",
+        "managements"
     ]
 }

--- a/apps/api/src/controllers/kpi.controller.ts
+++ b/apps/api/src/controllers/kpi.controller.ts
@@ -5,6 +5,7 @@ import {
     ApiBadRequestResponse,
     ApiBearerAuth,
     ApiCreatedResponse,
+    ApiExcludeController,
     ApiInternalServerErrorResponse,
     ApiNotFoundResponse,
     ApiOkResponse,
@@ -25,6 +26,7 @@ import { sendMessagePipeException } from '~libs/common/RabbitMQ/rmq.util';
 import { KpiDTO } from '~libs/resource/kpi';
 import { ObjectIdParamDTO } from '~libs/common/dtos';
 
+@ApiExcludeController()
 @ApiBadRequestResponse({
     description: 'Invalid request, please check your request data!',
 })

--- a/apps/order/src/checkout-ord/dtos/checkout-review-order-request.dto.ts
+++ b/apps/order/src/checkout-ord/dtos/checkout-review-order-request.dto.ts
@@ -21,18 +21,6 @@ export class ReviewOrderRequestDTO {
     }
 
     @ApiProperty({
-        description: 'Payment method, default is COD',
-        type: String,
-        enum: PaymentMethodEnum,
-        example: PaymentMethodEnum.COD,
-        required: false,
-    })
-    @IsOptional()
-    @IsStringI18n()
-    @IsEnumI18n(PaymentMethodEnum)
-    paymentMethod: string;
-
-    @ApiProperty({
         description: 'Index of address selected (index begin from 0)',
         example: 1,
         type: Number,
@@ -55,4 +43,16 @@ export class ReviewOrderRequestDTO {
     @Type(() => ProductCartDTO)
     @ValidateNested({ each: true })
     productSelected: Array<ProductCartDTO>;
+
+    @ApiProperty({
+        description: 'Payment method, default is COD',
+        type: String,
+        enum: PaymentMethodEnum,
+        example: PaymentMethodEnum.COD,
+        required: false,
+    })
+    @IsOptional()
+    @IsStringI18n()
+    @IsEnumI18n(PaymentMethodEnum)
+    paymentMethod: string;
 }

--- a/apps/order/src/checkout-ord/dtos/create-order-request.dto.ts
+++ b/apps/order/src/checkout-ord/dtos/create-order-request.dto.ts
@@ -1,8 +1,9 @@
 import { ApiProperty, IntersectionType } from '@nestjs/swagger';
 import { ReviewOrderRequestDTO } from './checkout-review-order-request.dto';
 import { ProductCartDTO } from '~libs/resource/carts/dtos/product-cart.dto';
-import { IsEnumI18n, IsNotEmptyI18n, IsStringI18n } from '~libs/common/i18n';
+import { IsEnumI18n, IsNotEmptyI18n, IsStringI18n, IsUrlI18n } from '~libs/common/i18n';
 import { PaymentMethodEnum } from '~libs/resource/orders/enums';
+import { IsOptional } from 'class-validator';
 
 export class CreateOrderRequestDTO extends IntersectionType(ReviewOrderRequestDTO) {
     constructor(data: CreateOrderRequestDTO) {
@@ -22,4 +23,14 @@ export class CreateOrderRequestDTO extends IntersectionType(ReviewOrderRequestDT
     @IsStringI18n()
     @IsEnumI18n(PaymentMethodEnum)
     paymentMethod: string;
+
+    @ApiProperty({
+        description: 'The return url after payment success',
+        example: 'http://localhost:3000/order/123',
+        required: false,
+    })
+    @IsOptional()
+    @IsStringI18n()
+    @IsUrlI18n()
+    paymentReturnUrl: string;
 }

--- a/libs/common/src/i18n/class-validator-i18n/validator-i18n.decorator.ts
+++ b/libs/common/src/i18n/class-validator-i18n/validator-i18n.decorator.ts
@@ -29,6 +29,8 @@ import {
     IsDateString,
     IsObject,
     IsUrl,
+    IsIP,
+    IsIpVersion,
 } from 'class-validator';
 import ValidatorJS from 'validator';
 import { I18nTranslations } from '~libs/common/i18n/generated';
@@ -287,6 +289,15 @@ export const IsUrlI18n = (
     return (target: object, key: string) => {
         IsUrl(options, {
             message: i18nValidationMessage('validation.IS_URL'),
+            ...validationOptions,
+        })(target, key);
+    };
+};
+
+export const IsIPI18n = (version?: IsIpVersion, validationOptions?: ValidationOptions) => {
+    return (target: object, key: string) => {
+        IsIP(version, {
+            message: i18nValidationMessage('validation.IS_IP'),
             ...validationOptions,
         })(target, key);
     };

--- a/libs/common/src/i18n/class-validator-i18n/validator-i18n.decorator.ts
+++ b/libs/common/src/i18n/class-validator-i18n/validator-i18n.decorator.ts
@@ -28,6 +28,7 @@ import {
     ArrayMaxSize,
     IsDateString,
     IsObject,
+    IsUrl,
 } from 'class-validator';
 import ValidatorJS from 'validator';
 import { I18nTranslations } from '~libs/common/i18n/generated';
@@ -274,6 +275,18 @@ export const IsObjectI18n = (validationOptions?: ValidationOptions) => {
     return (target: object, key: string) => {
         IsObject({
             message: i18nValidationMessage('validation.IS_OBJECT'),
+            ...validationOptions,
+        })(target, key);
+    };
+};
+
+export const IsUrlI18n = (
+    options?: ValidatorJS.IsURLOptions,
+    validationOptions?: ValidationOptions,
+) => {
+    return (target: object, key: string) => {
+        IsUrl(options, {
+            message: i18nValidationMessage('validation.IS_URL'),
             ...validationOptions,
         })(target, key);
     };

--- a/libs/common/src/i18n/generated/i18n.generated.ts
+++ b/libs/common/src/i18n/generated/i18n.generated.ts
@@ -110,6 +110,7 @@ export type I18nTranslations = {
         "ARRAY_MAX_SIZE": string;
         "IS_DATE_STRING": string;
         "IS_OBJECT": string;
+        "IS_URL": string;
     };
 };
 export type I18nPath = Path<I18nTranslations>;

--- a/libs/common/src/i18n/generated/i18n.generated.ts
+++ b/libs/common/src/i18n/generated/i18n.generated.ts
@@ -76,6 +76,7 @@ export type I18nTranslations = {
         "THIRD_PARTY_ERROR": string;
         "NOT_SUPPORT_SHIP": string;
         "CAN_NOT_CREATE_ORDER": string;
+        "RETURN_URL_REQUIRED": string;
     };
     "exception": {
         "InternalServerException": string;
@@ -111,6 +112,7 @@ export type I18nTranslations = {
         "IS_DATE_STRING": string;
         "IS_OBJECT": string;
         "IS_URL": string;
+        "IS_IP": string;
     };
 };
 export type I18nPath = Path<I18nTranslations>;

--- a/libs/common/src/i18n/lang/en/errorMessage.json
+++ b/libs/common/src/i18n/lang/en/errorMessage.json
@@ -54,5 +54,6 @@
     "START_DATE_MUST_BE_BEFORE_END_DATE": "Start date must be before end date.",
     "THIRD_PARTY_ERROR": "Some thing went wrong, please try again later.",
     "NOT_SUPPORT_SHIP": "Not support ship to this address yet.",
-    "CAN_NOT_CREATE_ORDER": "Can not create order, please try again later."
+    "CAN_NOT_CREATE_ORDER": "Can not create order, please try again later.",
+    "RETURN_URL_REQUIRED": "Return url is required for '{method}'"
 }

--- a/libs/common/src/i18n/lang/en/validation.json
+++ b/libs/common/src/i18n/lang/en/validation.json
@@ -26,5 +26,6 @@
     "ARRAY_MAX_SIZE": "{property} must have at most {constraints.0} elements",
     "IS_DATE_STRING": "{property} must be a valid date string",
     "IS_OBJECT": "{property} must be an object",
-    "IS_URL": "{property} must be a valid URL"
+    "IS_URL": "{property} must be a valid URL",
+    "IS_IP": "{property} must be an IP address"
 }

--- a/libs/common/src/i18n/lang/en/validation.json
+++ b/libs/common/src/i18n/lang/en/validation.json
@@ -25,5 +25,6 @@
     "ARRAY_MIN_SIZE": "{property} must have at least {constraints.0} elements",
     "ARRAY_MAX_SIZE": "{property} must have at most {constraints.0} elements",
     "IS_DATE_STRING": "{property} must be a valid date string",
-    "IS_OBJECT": "{property} must be an object"
+    "IS_OBJECT": "{property} must be an object",
+    "IS_URL": "{property} must be a valid URL"
 }

--- a/libs/common/src/i18n/lang/vi_VN/errorMessage.json
+++ b/libs/common/src/i18n/lang/vi_VN/errorMessage.json
@@ -54,5 +54,6 @@
     "START_DATE_MUST_BE_BEFORE_END_DATE": "Ngày bắt đầu phải trước ngày kết thúc.",
     "THIRD_PARTY_ERROR": "Đã xảy ra lỗi, vui lòng thử lại sau.",
     "NOT_SUPPORT_SHIP": "Chưa hỗ trợ vận chuyển đến địa chỉ này.",
-    "CAN_NOT_CREATE_ORDER": "Không thể tạo đơn hàng, vui lòng thử lại sau."
+    "CAN_NOT_CREATE_ORDER": "Không thể tạo đơn hàng, vui lòng thử lại sau.",
+    "RETURN_URL_REQUIRED": "Địa chỉ trả về là bắt buộc cho phương thức thanh toán '{method}'"
 }

--- a/libs/common/src/i18n/lang/vi_VN/validation.json
+++ b/libs/common/src/i18n/lang/vi_VN/validation.json
@@ -26,5 +26,6 @@
     "ARRAY_MAX_SIZE": "{property} phải có nhiều nhất {constraints.0} phần tử",
     "IS_DATE_STRING": "{property} phải là một chuỗi ngày, thời gian hợp lệ (Date)",
     "IS_OBJECT": "{property} phải là một đối tượng",
-    "IS_URL": "{property} phải là một URL hợp lệ"
+    "IS_URL": "{property} phải là một địa chỉ URL hợp lệ",
+    "IS_IP": "{property} phải là một địa chỉ IP hợp lệ"
 }

--- a/libs/common/src/i18n/lang/vi_VN/validation.json
+++ b/libs/common/src/i18n/lang/vi_VN/validation.json
@@ -25,5 +25,6 @@
     "ARRAY_MIN_SIZE": "{property} phải có ít nhất {constraints.0} phần tử",
     "ARRAY_MAX_SIZE": "{property} phải có nhiều nhất {constraints.0} phần tử",
     "IS_DATE_STRING": "{property} phải là một chuỗi ngày, thời gian hợp lệ (Date)",
-    "IS_OBJECT": "{property} phải là một đối tượng"
+    "IS_OBJECT": "{property} phải là một đối tượng",
+    "IS_URL": "{property} phải là một URL hợp lệ"
 }

--- a/libs/third-party/src/vnpay.vn/dtos/create-vnpay-url.dto.ts
+++ b/libs/third-party/src/vnpay.vn/dtos/create-vnpay-url.dto.ts
@@ -1,58 +1,62 @@
-import {
-    IsNotEmpty,
-    IsNumber,
-    IsString,
-    Max,
-    Min,
-    IsIP,
-    IsEnum,
-    IsOptional,
-} from 'class-validator';
+import { IsOptional } from 'class-validator';
 import { ProductCode } from '../enums';
 import { BankCode } from '../enums/bank-code.enum';
+import {
+    IsNotEmptyI18n,
+    IsStringI18n,
+    IsNumberI18n,
+    MinI18n,
+    MaxI18n,
+    IsIPI18n,
+    IsEnumI18n,
+} from '~libs/common/i18n';
 
 export class CreateVnpayUrlDTO {
     @IsOptional()
-    @IsString()
+    @IsStringI18n()
     vnp_Command?: string;
 
-    @IsNotEmpty()
-    @IsNumber()
-    @Min(1000000)
-    @Max(Number.MAX_VALUE)
+    @IsNotEmptyI18n()
+    @IsNumberI18n()
+    @MinI18n(1000000)
+    @MaxI18n(Number.MAX_VALUE)
     vnp_Amount: number;
 
-    @IsNotEmpty()
-    @IsString()
-    @IsIP()
+    @IsNotEmptyI18n()
+    @IsStringI18n()
+    @IsIPI18n()
     vnp_IpAddr: string;
 
     /**
      * @description Thông tin đơn hàng
      */
-    @IsNotEmpty()
-    @IsString()
+    @IsNotEmptyI18n()
+    @IsStringI18n()
     vnp_OrderInfo: string;
 
     /**
      * @description Loại hàng hóa
      */
-    @IsNotEmpty()
-    @IsEnum(ProductCode)
+    @IsNotEmptyI18n()
+    @IsEnumI18n(ProductCode)
     vnp_OrderType: string;
 
     /**
      * @description Mã ngân hàng
      */
     @IsOptional()
-    @IsString()
-    @IsEnum(BankCode)
+    @IsStringI18n()
+    @IsEnumI18n(BankCode)
     bankCode?: string;
 
     /**
      * @description Mã đơn hàng
      */
-    @IsNotEmpty()
-    @IsString()
+    @IsNotEmptyI18n()
+    @IsStringI18n()
     vnp_TxnRef: string;
+
+    @IsStringI18n()
+    @IsNotEmptyI18n()
+    vnp_ReturnUrl: string;
 }


### PR DESCRIPTION
# Summary:

- Add `paymentReturnUrl` when create order for redirect user to front-end page after payment process end
- Update validate i18n message
- Update `paymentReturnUrl` required when `paymentMethod` is not COD